### PR TITLE
refactor: implement as Set[constraint.Ordered]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/daynemay/goset
 
 go 1.18
+
+require golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd h1:zVFyTKZN/Q7mNRWSs1GOYnHM9NiFSJ54YVRsD0rNWT4=
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=

--- a/set.go
+++ b/set.go
@@ -4,19 +4,21 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"golang.org/x/exp/constraints"
 )
 
 var exists = struct{}{}
 
-// Set represents a (mathematical) set of strings, supporting the set concepts of Union, Intersection, Difference
-type Set struct {
-	members map[string]struct{}
+// Set represents a (mathematical) set of values, supporting the set concepts of Union, Intersection, Difference
+type Set[T constraints.Ordered] struct {
+	members map[T]struct{}
 }
 
 // New returns a new Set, optionally initialized with some members
-func New(members ...string) Set {
-	newSet := Set{
-		members: map[string]struct{}{},
+func New[T constraints.Ordered](members ...T) Set[T] {
+	newSet := Set[T]{
+		members: map[T]struct{}{},
 	}
 	for _, entry := range members {
 		newSet.members[entry] = exists
@@ -25,13 +27,13 @@ func New(members ...string) Set {
 }
 
 // String returns a string representation of theSet
-func (theSet Set) String() string {
+func (theSet Set[T]) String() string {
 	asListString := fmt.Sprintf("%#v", theSet.AsSortedList())
 	return strings.Replace(asListString, "[]string", "Set", 1)
 }
 
 // Add adds a member to a Set, ignoring it if is already present
-func (theSet Set) Add(members ...string) Set {
+func (theSet Set[T]) Add(members ...T) Set[T] {
 	for _, member := range members {
 		theSet.members[member] = exists
 	}
@@ -39,8 +41,8 @@ func (theSet Set) Add(members ...string) Set {
 }
 
 // Contains returns a boolean indicating whether theSet contains all the given strs
-func (theSet Set) Contains(strs ...string) bool {
-	for _, s := range strs {
+func (theSet Set[T]) Contains(values ...T) bool {
+	for _, s := range values {
 		if _, ok := theSet.members[s]; !ok {
 			return false
 		}
@@ -49,41 +51,41 @@ func (theSet Set) Contains(strs ...string) bool {
 }
 
 // Equals returns a boolean indicating whether theSet is set-equal to other
-func (theSet Set) Equals(other Set) bool {
-	asList := theSet.AsList()
-	sort.Strings(asList)
-	otherAsList := other.AsList()
-	sort.Strings(otherAsList)
-	if len(asList) != len(otherAsList) {
+func (theSet Set[T]) Equals(other Set[T]) bool {
+	if theSet.Count() != other.Count() {
 		return false
 	}
-	for idx := range asList {
-		if asList[idx] != otherAsList[idx] {
+	asList := theSet.AsList()
+	for _, entry := range asList {
+		if !other.Contains(entry) {
 			return false
 		}
 	}
 	return true
 }
 
-// AsList returns a slice of strings in theSet
-func (theSet Set) AsList() []string {
-	asList := []string{}
+// AsList returns a slice of values in theSet
+func (theSet Set[T]) AsList() []T {
+	asList := []T{}
 	for entry := range theSet.members {
 		asList = append(asList, entry)
 	}
 	return asList
 }
 
-// AsSortedList returns a sorted slice of strings in theSet
-func (theSet Set) AsSortedList() []string {
+// AsSortedList returns a sorted slice of values in theSet
+func (theSet Set[T]) AsSortedList() []T {
 	asList := theSet.AsList()
-	sort.Strings(asList)
+	isLess := func(i, j int) bool {
+		return asList[i] < asList[j]
+	}
+	sort.SliceStable(asList, isLess)
 	return asList
 }
 
 // Intersect returns a new Set resulting from the set intersection of theSet and other
-func (theSet Set) Intersect(other Set) Set {
-	commonMembers := []string{}
+func (theSet Set[T]) Intersect(other Set[T]) Set[T] {
+	commonMembers := []T{}
 	for member := range theSet.members {
 		if other.Contains(member) {
 			commonMembers = append(commonMembers, member)
@@ -93,8 +95,8 @@ func (theSet Set) Intersect(other Set) Set {
 }
 
 // Minus returns a new set representing the set difference theSet - other
-func (theSet Set) Minus(other Set) Set {
-	difference := New()
+func (theSet Set[T]) Minus(other Set[T]) Set[T] {
+	difference := New[T]()
 	for member := range theSet.members {
 		if !other.Contains(member) {
 			difference.Add(member)
@@ -104,34 +106,34 @@ func (theSet Set) Minus(other Set) Set {
 }
 
 // Clone returns a copy of this Set
-func (theSet Set) Clone() Set {
+func (theSet Set[T]) Clone() Set[T] {
 	return New(theSet.AsList()...)
 }
 
 // Union returns a new Set resulting from the set union of theSet and other
-func (theSet Set) Union(other Set) Set {
+func (theSet Set[T]) Union(other Set[T]) Set[T] {
 	union := theSet.Clone()
 	union.Add(other.AsList()...)
 	return union
 }
 
-func (theSet Set) IsSubsetOf(other Set) bool {
+func (theSet Set[T]) IsSubsetOf(other Set[T]) bool {
 	return theSet.Intersect(other).Equals(theSet)
 }
 
-func (theSet Set) IsProperSubsetOf(other Set) bool {
+func (theSet Set[T]) IsProperSubsetOf(other Set[T]) bool {
 	return theSet.IsSubsetOf(other) && !theSet.Equals(other)
 }
 
-func (theSet Set) IsSupersetOf(other Set) bool {
+func (theSet Set[T]) IsSupersetOf(other Set[T]) bool {
 	return other.IsSubsetOf(theSet)
 }
 
-func (theSet Set) IsProperSupersetOf(other Set) bool {
+func (theSet Set[T]) IsProperSupersetOf(other Set[T]) bool {
 	return theSet.IsSupersetOf(other) && !theSet.Equals(other)
 }
 
 // Count returns the set cardinality of theSet
-func (theSet Set) Count() int {
+func (theSet Set[T]) Count() int {
 	return len(theSet.members)
 }

--- a/set_test.go
+++ b/set_test.go
@@ -14,7 +14,7 @@ func expect(t *testing.T, condition bool, description string, subs ...interface{
 func TestNew(t *testing.T) {
 
 	t.Run("New should return an empty set by default", func(t *testing.T) {
-		count := New().Count()
+		count := New[string]().Count()
 		expect(t, count == 0, "NewSet().Count() = %v, expected 0", count)
 	})
 
@@ -36,7 +36,7 @@ func TestNew(t *testing.T) {
 
 func TestSet_String(t *testing.T) {
 	t.Run("String() of an empty set", func(t *testing.T) {
-		actual := New().String()
+		actual := New[string]().String()
 		expected := "Set{}"
 		expect(t, actual == expected, "Expected empty set to String to %s, was %v", expected, actual)
 	})
@@ -57,14 +57,14 @@ func TestSet_String(t *testing.T) {
 
 func TestSet_Add(t *testing.T) {
 	t.Run("Adding a new member should result increase the size of the set", func(t *testing.T) {
-		set := New()
+		set := New[string]()
 		expect(t, set.Count() == 0, "Sanity check, expected to be empty")
 		set.Add("guile")
 		expect(t, set.Count() == 1, "Expect set to increase in size after Add()ing new member")
 	})
 
 	t.Run("Adding a new member should result in the presence of the member in the set", func(t *testing.T) {
-		set := New()
+		set := New[string]()
 		expect(t, !set.Contains("guile"), "Expect set not to contain new member initially")
 		set.Add("guile")
 		expect(t, set.Contains("guile"), "Expect set to contain new member after Add()ing new member")
@@ -92,13 +92,13 @@ func TestSet_Contains(t *testing.T) {
 	})
 
 	t.Run("Set.Contains() members Add()ed to it", func(t *testing.T) {
-		set := New()
+		set := New[string]()
 		set.Add("balrog", "guile")
 		expect(t, set.Contains("guile"), "Expected set to contain guile")
 	})
 
 	t.Run("Set.Contains() must contain all arguments", func(t *testing.T) {
-		set := New()
+		set := New[string]()
 		set.Add("balrog", "guile")
 		expect(t, !set.Contains("guile", "honda"), "Expected set not to contain guile-and-honda")
 	})
@@ -106,7 +106,7 @@ func TestSet_Contains(t *testing.T) {
 
 func TestStringSeq_Equals(t *testing.T) {
 	t.Run("Two empty sets should be equal", func(t *testing.T) {
-		expect(t, New().Equals(New()), "Expect two empty sets to be equal")
+		expect(t, New[string]().Equals(New[string]()), "Expect two empty sets to be equal")
 	})
 
 	t.Run("Two sets with the same members should be Equal()", func(t *testing.T) {
@@ -167,13 +167,13 @@ func TestSet_Union(t *testing.T) {
 
 func TestSet_Minus(t *testing.T) {
 	t.Run("Empty set minus empty set should be empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		difference := empty.Minus(empty)
 		expect(t, difference.Equals(empty), "Empty set minus empty set should be empty set")
 	})
 
 	t.Run("Empty set minus non-empty set should be empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		nonEmpty := New("dhalsim", "honda", "vega")
 		difference := empty.Minus(nonEmpty)
 		expect(t, difference.Equals(empty), "Empty set minus non-empty set should be empty set")
@@ -181,7 +181,7 @@ func TestSet_Minus(t *testing.T) {
 
 	t.Run("Non-empty minus empty set should be equal to the original set", func(t *testing.T) {
 		nonEmpty := New("dhalsim", "honda", "vega")
-		empty := New()
+		empty := New[string]()
 		difference := nonEmpty.Minus(empty)
 		expect(t, difference.Equals(nonEmpty), "Original set minus empty should be equal to original set")
 	})
@@ -197,7 +197,7 @@ func TestSet_Minus(t *testing.T) {
 
 func TestSet_Clone(t *testing.T) {
 	t.Run("Clone of empty set should be empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		clone := empty.Clone()
 		expect(t, clone.Count() == 0, "Clone of empty set should be of size zero")
 	})
@@ -210,7 +210,7 @@ func TestSet_Clone(t *testing.T) {
 	})
 
 	t.Run("Mutation of clone should not affect original", func(t *testing.T) {
-		original := New()
+		original := New[string]()
 		clone := original.Clone()
 		clone.Add("deejay")
 		expect(t, clone.Contains("deejay"), "Clone should contain new member")
@@ -218,7 +218,7 @@ func TestSet_Clone(t *testing.T) {
 	})
 
 	t.Run("Mutation of original should not affect clone", func(t *testing.T) {
-		original := New()
+		original := New[string]()
 		clone := original.Clone()
 		original.Add("cammy")
 		expect(t, original.Contains("cammy"), "Original should contain new member")
@@ -228,13 +228,13 @@ func TestSet_Clone(t *testing.T) {
 
 func TestSet_IsSubsetOf(t *testing.T) {
 	t.Run("Empty set is a subset of empty set", func(t *testing.T) {
-		empty := New()
-		otherEmpty := New()
+		empty := New[string]()
+		otherEmpty := New[string]()
 		expect(t, empty.IsSubsetOf(otherEmpty), "Empty set should be a subset of empty set")
 	})
 
 	t.Run("Empty set is a subset of a non-empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		nonEmpty := New("dhalsim", "honda", "vega")
 		expect(t, empty.IsSubsetOf(nonEmpty), "Empty set should be a subset of non-empty set")
 	})
@@ -262,13 +262,13 @@ func TestSet_IsSubsetOf(t *testing.T) {
 
 func TestSet_IsProperSubsetOf(t *testing.T) {
 	t.Run("Empty set is not a proper subset of empty set", func(t *testing.T) {
-		empty := New()
-		otherEmpty := New()
+		empty := New[string]()
+		otherEmpty := New[string]()
 		expect(t, !empty.IsProperSubsetOf(otherEmpty), "Empty set is not a proper subset of empty set")
 	})
 
 	t.Run("Empty set is a proper subset of a non-empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		nonEmpty := New("dhalsim", "honda", "vega")
 		expect(t, empty.IsProperSubsetOf(nonEmpty), "Empty set is a proper subset of a non-empty set")
 	})
@@ -296,13 +296,13 @@ func TestSet_IsProperSubsetOf(t *testing.T) {
 
 func TestSet_IsSupersetOf(t *testing.T) {
 	t.Run("Empty set is a superset of empty set", func(t *testing.T) {
-		empty := New()
-		otherEmpty := New()
+		empty := New[string]()
+		otherEmpty := New[string]()
 		expect(t, empty.IsSupersetOf(otherEmpty), "Empty set should be a superset of empty set")
 	})
 
 	t.Run("Non-empty is a superset of empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		nonEmpty := New("dhalsim", "honda", "vega")
 		expect(t, nonEmpty.IsSupersetOf(empty), "Non-empty should be a superset of empty set")
 	})
@@ -330,13 +330,13 @@ func TestSet_IsSupersetOf(t *testing.T) {
 
 func TestSet_IsProperSupersetOf(t *testing.T) {
 	t.Run("Empty set is not a proper superset of empty set", func(t *testing.T) {
-		empty := New()
-		otherEmpty := New()
+		empty := New[string]()
+		otherEmpty := New[string]()
 		expect(t, !empty.IsProperSupersetOf(otherEmpty), "Empty set is not a proper superset of empty set")
 	})
 
 	t.Run("Non-empty set is a proper superset of empty set", func(t *testing.T) {
-		empty := New()
+		empty := New[string]()
 		nonEmpty := New("dhalsim", "honda", "vega")
 		expect(t, nonEmpty.IsProperSupersetOf(empty), "Non-empty set is a proper superset of empty set")
 	})


### PR DESCRIPTION
Refactor Set to be, rather than a set of string items, a set of items that satisfy the `constraints.Ordered` type. This type is [defined](https://pkg.go.dev/golang.org/x/exp/constraints#Ordered) as 

```golang
type Ordered interface {
	Integer | Float | ~string
}
```

